### PR TITLE
refs #4 chatclienthandlerクラスとrunメソッドの作成

### DIFF
--- a/src/main/java/com/github/chat/ChatClientHandler.java
+++ b/src/main/java/com/github/chat/ChatClientHandler.java
@@ -1,3 +1,5 @@
+package com.github.chat;
+
 import java.io.*;
 import java.net.*;
 import java.util.*;

--- a/src/main/java/com/github/chat/ChatClientHandler.java
+++ b/src/main/java/com/github/chat/ChatClientHandler.java
@@ -1,0 +1,33 @@
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+/**
+* サーバのハンドラを作成し, 複数のクライアントに対応する.
+*/
+class ChatClientHandler extends Thread
+{
+	ArrayList<ChatClientHandler> clients = new ArrayList<ChatClientHandler>();
+	private Socket socket;
+	String name;
+	
+	 /**
+ 	 * コンストラクタ
+	 */	
+	ChatClientHandler(Socket socket, ArrayList<ChatClientHandler> clients)
+	{
+		this.socket = socket;
+		this.clients = clients;
+		this.name = "undefiend"+(clients.size()+1);
+		this.clientNumber = clients.size();
+	}
+
+
+	/**
+	* コマンドを受け付け, 対応する各処理を行う.
+	*/
+	public void run()
+	{
+
+	}
+}


### PR DESCRIPTION
ChatClientHandlerクラスを作成し, ChatServerに対応する引数を与えたコンストラクタを用意.
複数のクライアントを受け付けるために, スレッドを継承し, スレッドの実行メソッドとなるrun()を実装.
必要に応じた, import文とフィールドに変数を追加した.
